### PR TITLE
removed meta tag

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-giJF6kkoqNQ00vy+HMDP7azOuL0xtbfIcaT9wjKHr8RbDVddVHyTfAAsrekwKmP1" crossorigin="anonymous">
     <style>


### PR DESCRIPTION
This meta-tag broke the numbers API link as it only has HTTP and has no HTTPS.
"<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">"